### PR TITLE
Updated React version in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "j2c": "^0.7.3"
   },
   "peerDependencies": {
-    "react": ">=0.13.2 || ^0.14.0-beta3"
+    "react": ">=0.13.2 || ^0.14.0-rc1"
   },
   "devDependencies": {
     "babel": "^5.8.23"


### PR DESCRIPTION
As React 0.14 RC1 was released, and `delicate-error-reporter` had `beta3` as a peerDependency, I was unable to test it out in an existing project. This pull request should fix NPM errors coming from that.
